### PR TITLE
Fixed an issue on Python 3.8+ systems where time.clock() was removed.…

### DIFF
--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -15,12 +15,12 @@ def RateLimited(maxPerSecond):
         lastTimeCalled = [0.0]
 
         def rateLimitedFunction(*args, **kargs):
-            elapsed = time.clock() - lastTimeCalled[0]
+            elapsed = time.perf_counter() - lastTimeCalled[0]
             leftToWait = minInterval - elapsed
             if leftToWait > 0:
                 time.sleep(leftToWait)
             ret = func(*args, **kargs)
-            lastTimeCalled[0] = time.clock()
+            lastTimeCalled[0] = time.perf_counter()
             return ret
 
         return rateLimitedFunction


### PR DESCRIPTION
… Closes #4.